### PR TITLE
Validação do campo Year #1

### DIFF
--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -378,6 +378,13 @@ public class BibEntry {
             fields.put(fieldName, oldValue);
             throw new IllegalArgumentException("Change rejected: " + pve);
         }
+
+        if (fieldName.equals("year")) {
+            int newYear = Integer.parseInt(value);
+            if (newYear > Calendar.getInstance().get(Calendar.YEAR)) {
+                throw new IllegalArgumentException("This year is invalid: " + newYear);
+            }
+        }
     }
 
     /**
@@ -651,4 +658,5 @@ public class BibEntry {
     public int hashCode() {
         return Objects.hash(type, fields);
     }
+
 }


### PR DESCRIPTION
### Próposito:
Fazer a validação do campo "year" na funcionalidade **Inserção de item bibliográfico** ( _BibTeX → New entry_ ), para as categorias Book e Article.

### Como verificar esse MR:
-Verificar se é possível inserir um ano maior que o atual. _(Nesse caso não deve deixar inserir)_
-Verificar se é possível inserir um ano menor ou igual ao atual. _(Nesse caso deve deixar inserir)_
-Verificar se é mostrado uma caixa de Error ao tentar inserir um ano invalido.


### Screenshots:
![Captura de tela de 2020-10-03 18-26-09](https://user-images.githubusercontent.com/22521448/95002025-0d40e980-05a6-11eb-9737-ade768d03b1e.png)


