### PR TITLE
Validação do campo BibtexKey #2

### DIFF
--- a/src/main/java/net/sf/jabref/model/entry/BibEntry.java
+++ b/src/main/java/net/sf/jabref/model/entry/BibEntry.java
@@ -33,6 +33,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Random;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -377,6 +378,30 @@ public class BibEntry {
             // the change was rejected:
             fields.put(fieldName, oldValue);
             throw new IllegalArgumentException("Change rejected: " + pve);
+        }
+
+        if (fieldName.equals("bibtexkey")) {
+            if (!Character.isLetter(value.toString().charAt(0)) || (value.length() < 2)) {
+                String char1 = "AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz";
+                String char2 = "0123456789AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz";
+                StringBuilder randomKey = new StringBuilder();
+
+                Random rand = new Random();
+
+                while (randomKey.length() < 6) {
+                    int i = (int) (rand.nextFloat() * randomKey.length());
+                    if (randomKey.length() == 0) {
+                        randomKey.append(char1.charAt(i));
+                    } else {
+                        randomKey.append(char2.charAt(i));
+                    }
+                }
+
+                String newKey = randomKey.toString();
+                fields.put("bibtexkey", newKey);
+            } else {
+                fields.put(fieldName, value);
+            }
         }
     }
 


### PR DESCRIPTION
### Próposito:
Fazer a validação do campo "bibtexkey" na funcionalidade **Inserção de item bibliográfico** ( _BibTeX → New entry_ ), para as categorias Book e Article.

### Como verificar esse MR:
-Verificar se a key é maior que 2 caracteres.
-Verificar se a o primeiro carácter é uma letra podendo ser maiúscula ou minuscula.
-Verificar se quando inserir uma key menor que 2 caracteres se está gerando automaticamente uma key com o padrão certo. 

### Screenshots:
![Captura de tela de 2020-10-03 18-43-13](https://user-images.githubusercontent.com/22521448/95002334-0bc4f080-05a9-11eb-9619-50fee7320b5a.png)




